### PR TITLE
Wordcloud class names and no more SASS

### DIFF
--- a/src/jqcloud.scss
+++ b/src/jqcloud.scss
@@ -1,22 +1,5 @@
-$jqcloud-font: 10px "Helvetica", "Arial", sans-serif;
-
-$jqcloud-link-hover-color: #00ccff;
-
-$jqcloud-words: (
-        w1: (100%, #aab5f0),
-        w2: (150%, #99ccee),
-        w3: (200%, #a0ddff),
-        w4: (250%, #90c5f0),
-        w5: (300%, #90a0dd),
-        w6: (350%, #90c5f0),
-        w7: (400%, #3399dd),
-        w8: (450%, #00ccff),
-        w9: (500%, #00ccff),
-        w10: (550%, #00ccff)
-) !default;
-
 .jqcloud {
-  font: $jqcloud-font;
+  font: 10px "Helvetica", "Arial", sans-serif;
   line-height: normal;
   overflow: hidden;
   position: relative;
@@ -25,21 +8,54 @@ $jqcloud-words: (
 .jqcloud-word {
   margin: 0;
   padding: 0;
+}
 
-  @each $word, $config in $jqcloud-words {
-    &.#{$word} {
-      color: nth($config, 2);
-      font-size: nth($config, 1);
-    }
-  }
+.jqcloud-word.w1 {
+  color: #aab5f0;
+  font-size: 100%;
+}
+.jqcloud-word.w2 {
+  color: #99ccee;
+  font-size: 150%;
+}
+.jqcloud-word.w3 {
+  color: #a0ddff;
+  font-size: 200%;
+}
+.jqcloud-word.w4 {
+  color: #90c5f0;
+  font-size: 250%;
+}
+.jqcloud-word.w5 {
+  color: #90a0dd;
+  font-size: 300%;
+}
+.jqcloud-word.w6 {
+  color: #90c5f0;
+  font-size: 350%;
+}
+.jqcloud-word.w7 {
+  color: #3399dd;
+  font-size: 400%;
+}
+.jqcloud-word.w8 {
+  color: #00ccff;
+  font-size: 450%;
+}
+.jqcloud-word.w9 {
+  color: #00ccff;
+  font-size: 500%;
+}
+.jqcloud-word.w10 {
+  color: #00ccff;
+  font-size: 550%;
+}
 
-  a {
-    color: inherit;
-    font-size: inherit;
-    text-decoration: none;
-
-    &:hover {
-      color: $jqcloud-link-hover-color;
-    }
-  }
+.jqcloud-word a {
+  color: inherit;
+  font-size: inherit;
+  text-decoration: none;
+}
+.jqcloud-word a:hover {
+  color: #00ccff;
 }

--- a/src/wordcloud.css
+++ b/src/wordcloud.css
@@ -1,61 +1,61 @@
-.jqcloud {
+.wordcloud {
   font: 10px "Helvetica", "Arial", sans-serif;
   line-height: normal;
   overflow: hidden;
   position: relative;
 }
 
-.jqcloud-word {
+.wordcloud-word {
   margin: 0;
   padding: 0;
 }
 
-.jqcloud-word.w1 {
+.wordcloud-word.w1 {
   color: #aab5f0;
   font-size: 100%;
 }
-.jqcloud-word.w2 {
+.wordcloud-word.w2 {
   color: #99ccee;
   font-size: 150%;
 }
-.jqcloud-word.w3 {
+.wordcloud-word.w3 {
   color: #a0ddff;
   font-size: 200%;
 }
-.jqcloud-word.w4 {
+.wordcloud-word.w4 {
   color: #90c5f0;
   font-size: 250%;
 }
-.jqcloud-word.w5 {
+.wordcloud-word.w5 {
   color: #90a0dd;
   font-size: 300%;
 }
-.jqcloud-word.w6 {
+.wordcloud-word.w6 {
   color: #90c5f0;
   font-size: 350%;
 }
-.jqcloud-word.w7 {
+.wordcloud-word.w7 {
   color: #3399dd;
   font-size: 400%;
 }
-.jqcloud-word.w8 {
+.wordcloud-word.w8 {
   color: #00ccff;
   font-size: 450%;
 }
-.jqcloud-word.w9 {
+.wordcloud-word.w9 {
   color: #00ccff;
   font-size: 500%;
 }
-.jqcloud-word.w10 {
+.wordcloud-word.w10 {
   color: #00ccff;
   font-size: 550%;
 }
 
-.jqcloud-word a {
+.wordcloud-word a {
   color: inherit;
   font-size: inherit;
   text-decoration: none;
 }
-.jqcloud-word a:hover {
+.wordcloud-word a:hover {
   color: #00ccff;
 }

--- a/src/wordcloud.js
+++ b/src/wordcloud.js
@@ -36,7 +36,8 @@ class Wordcloud { // eslint-disable-line no-unused-vars
       autoResize: false,
       colors: null,
       fontSize: null,
-      template: null
+      template: null,
+      random: Math.random
     }
 
     this.initialize()
@@ -115,7 +116,7 @@ class Wordcloud { // eslint-disable-line no-unused-vars
       }
     }
 
-    this.data.angle = Math.random() * 6.28
+    this.data.angle = this.options.random() * 6.28
     this.data.step = (this.options.shape === 'rectangular') ? 18.0 : 2.0
     this.data.aspect_ratio = this.options.width / this.options.height
     this.clearTimeouts()
@@ -346,16 +347,16 @@ class Wordcloud { // eslint-disable-line no-unused-vars
 
         switch (quarterTurns % 4) {
           case 1:
-            wordSize.left += this.data.step * this.data.aspect_ratio + Math.random() * 2.0
+            wordSize.left += this.data.step * this.data.aspect_ratio + this.options.random() * 2.0
             break
           case 2:
-            wordSize.top -= this.data.step + Math.random() * 2.0
+            wordSize.top -= this.data.step + this.options.random() * 2.0
             break
           case 3:
-            wordSize.left -= this.data.step * this.data.aspect_ratio + Math.random() * 2.0
+            wordSize.left -= this.data.step * this.data.aspect_ratio + this.options.random() * 2.0
             break
           case 0:
-            wordSize.top += this.data.step + Math.random() * 2.0
+            wordSize.top += this.data.step + this.options.random() * 2.0
             break
         }
       } else { // Default settings: elliptic spiral shape

--- a/src/wordcloud.js
+++ b/src/wordcloud.js
@@ -124,7 +124,7 @@ class Wordcloud { // eslint-disable-line no-unused-vars
     // Namespace word ids to avoid collisions between multiple clouds
     this.data.namespace = (this.element.id || Math.floor((Math.random() * 1000000)).toString(36)) + '_word_'
 
-    this.element.classList.add('jqcloud')
+    this.element.classList.add('wordcloud')
 
     // Container's CSS position cannot be 'static'
     if (window.getComputedStyle(this.element).position === 'static') {
@@ -271,7 +271,7 @@ class Wordcloud { // eslint-disable-line no-unused-vars
       }
     }
 
-    wordSpan.classList.add('jqcloud-word')
+    wordSpan.classList.add('wordcloud-word')
 
     // Apply class
     if (this.options.classPattern) {
@@ -423,7 +423,7 @@ class Wordcloud { // eslint-disable-line no-unused-vars
     }
 
     this.clearTimeouts()
-    this.element.classList.remove('jqcloud')
+    this.element.classList.remove('wordcloud')
     this.element.querySelectorAll('*[id^="' + this.data.namespace + '"]').forEach(node => node.remove())
   }
 


### PR DESCRIPTION
Remove the dependency on SASS (making the stylesheet usable again) and making use of the opportunity to change the class names to no longer refer to jQCloud.